### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,25 +5,25 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-MCP4261 KEYWORD1
-mcp4261 KEYWORD1
+MCP4261	KEYWORD1
+mcp4261	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-write KEYWORD2
-read  KEYWORD2
-getW0Pos  KEYWORD2
-getW0NVPos  KEYWORD2
-getW1Pos  KEYWORD2
-getW1NVPos  KEYWORD2
-setW0Pos  KEYWORD2
-setW0NVPos  KEYWORD2
-setW1Pos  KEYWORD2
-setW1NVPos  KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+getW0Pos	KEYWORD2
+getW0NVPos	KEYWORD2
+getW1Pos	KEYWORD2
+getW1NVPos	KEYWORD2
+setW0Pos	KEYWORD2
+setW0NVPos	KEYWORD2
+setW1Pos	KEYWORD2
+setW1NVPos	KEYWORD2
 enable	KEYWORD2
-protectNV KEYWORD2
-readTcon  KEYWORD2
-writeTcon KEYWORD2
-readStatus  KEYWORD2
-wiperOn KEYWORD2
+protectNV	KEYWORD2
+readTcon	KEYWORD2
+writeTcon	KEYWORD2
+readStatus	KEYWORD2
+wiperOn	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords